### PR TITLE
Add a repro of static abstract in interfaces failing the build

### DIFF
--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/PresentationCore.csproj
@@ -9,6 +9,7 @@
     <GenerateResourcesSRNamespace>MS.Internal.PresentationCore</GenerateResourcesSRNamespace>
     <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
     <Platforms>AnyCPU;x64;arm64</Platforms>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,6 +20,7 @@
   <ItemGroup>
     <Compile Include="$(WpfCommonDir)\src\System\LocalAppContext.cs" />
     <Compile Include="$(WpfCommonDir)\src\System\AppContextDefaultValues.cs" />
+    <Compile Include="TestStaticAbstracts.cs" />
     <Compile Include="System\AppContextDefaultValues.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/TestStaticAbstracts.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/TestStaticAbstracts.cs
@@ -1,0 +1,21 @@
+﻿using System.Runtime.Versioning;
+
+namespace TestStaticAbstracts
+{
+    [RequiresPreviewFeatures]
+    public interface ITestStaticAbstracts<T>
+    {
+        static abstract T Create();
+    }
+
+    public struct TestStaticAbstractsPass
+    {
+        public static int Create() => 5;
+    }
+
+    [RequiresPreviewFeatures]
+    public struct TestStaticAbstractsFail : ITestStaticAbstracts<int>
+    {
+        public static int Create() => 42;
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/TestStaticAbstracts.cs
+++ b/src/Microsoft.DotNet.Wpf/src/PresentationCore/ref/TestStaticAbstracts.cs
@@ -1,0 +1,21 @@
+﻿using System.Runtime.Versioning;
+
+namespace TestStaticAbstracts
+{
+    [RequiresPreviewFeatures]
+    public interface ITestStaticAbstracts<T>
+    {
+        static abstract T Create();
+    }
+
+    public struct TestStaticAbstractsPass
+    {
+        public static int Create() => throw null;
+    }
+
+    [RequiresPreviewFeatures]
+    public struct TestStaticAbstractsFail : ITestStaticAbstracts<int>
+    {
+        public static int Create() => throw null;
+    }
+}

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/System.Printing.vcxproj
@@ -122,6 +122,7 @@
     <CLCompile Include="CPP\src\PrintJobSettings.cpp" />
     <CLCompile Include="CPP\src\PrintDocumentImageableArea.cpp" />
     <CLCompile Include="CPP\src\InteropAttributeValueDictionary.cpp" />
+    <ClCompile Include="TestStaticAbstracts.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(WpfSourceDir)System.Xaml\System.Xaml.csproj">

--- a/src/Microsoft.DotNet.Wpf/src/System.Printing/TestStaticAbstracts.cpp
+++ b/src/Microsoft.DotNet.Wpf/src/System.Printing/TestStaticAbstracts.cpp
@@ -1,0 +1,9 @@
+#include "win32inc.hpp"
+
+int test_static_abstracts()
+{
+    int pass = TestStaticAbstracts::TestStaticAbstractsPass::Create();
+    int fail = TestStaticAbstracts::TestStaticAbstractsFail::Create();
+
+    return fail;
+}


### PR DESCRIPTION
This illustrates a repro of using static abstract in interfaces within the WPF solution, which is currently failing due to an issue in C++/CLI. Attempting to build from this branch will result in the following build errors:

```
Build FAILED.

C:\git\dotnet\wpf\src\Microsoft.DotNet.Wpf\src\System.Printing\TestStaticAbstracts.cpp(6): error C2253: 'TestStaticAbstracts::ITestStaticAbstracts::Create': pure specifier or a
bstract override specifier only allowed on virtual function [C:\git\dotnet\wpf\src\Microsoft.DotNet.Wpf\src\System.Printing\System.Printing.vcxproj]
C:\git\dotnet\wpf\src\Microsoft.DotNet.Wpf\src\System.Printing\TestStaticAbstracts.cpp(6): error C2253: 'TestStaticAbstracts::ITestStaticAbstracts<int>::Create': pure specifier
 or abstract override specifier only allowed on virtual function [C:\git\dotnet\wpf\src\Microsoft.DotNet.Wpf\src\System.Printing\System.Printing.vcxproj]
    0 Warning(s)
    2 Error(s)

Time Elapsed 00:00:35.70
Build failed with exit code 1. Check errors above.
```

Once WPF takes in the updated C++/CLI tooling that includes the fix for this scenario, this branch should compile without error.